### PR TITLE
Updates default version to packer 0.5.2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,22 +1,22 @@
 node.default[:packer][:url_base] = "https://dl.bintray.com/mitchellh/packer"
-node.default[:packer][:version] = "0.5.1"
+node.default[:packer][:version] = "0.5.2"
 node.default[:packer][:arch] = kernel['machine'] =~ /x86_64/ ? "amd64" : "386"
 
 # Transform raw output of the bintray checksum list into a Hash[filename, checksum].
 # https://dl.bintray.com/mitchellh/packer/${VERSION}_SHA256SUMS?direct
 node.default[:packer][:raw_checksums] = <<-EOF
-    a0d8db4944d0024af05e256357cad014662eddefef67b1b2fe8a5060659a5be2  0.5.1_darwin_386.zip
-    56bec31f0d3540d566ef86979b25367660d7e72c010c9d87ef91c5c2138e9eae  0.5.1_darwin_amd64.zip
-    337651f4dd4f897413eb07e8d2cd821a0246d04c4235ce398af58f7939e097e1  0.5.1_freebsd_386.zip
-    ae356b68517aa75d08736c44d838b6bd4a19203315ee8afffff5de35684e1464  0.5.1_freebsd_amd64.zip
-    bbd2468d69195b4227034aa07474e87c2bcfe2250ae620085219e870e6b33bf6  0.5.1_freebsd_arm.zip
-    cc7741165a3d5f66c1d4af3ea3b1e80ebe03cb2ce5e0ff27ff43ecac64f1dc7a  0.5.1_linux_386.zip
-    fa68149f4356ad48a6393dbf9e81839a40aad115e5bad83833ff9ccf6a0239b8  0.5.1_linux_amd64.zip
-    6a6b724df3bc51478cc1cd4ccbc000924bbe9018a4ded74d3b6e0409cb9092e0  0.5.1_linux_arm.zip
-    a2ff5410a871baafef2ffd1924f5b6d7fe1ba443ba0b23071e2c928935d173e6  0.5.1_openbsd_386.zip
-    41c1edd5faf9041081f1dbaa6eb14e9f18cdb25a8dab85f33c08701bd0275817  0.5.1_openbsd_amd64.zip
-    350480400d31c00e1604fce8744b5f3d279c15cf8c49cd7b59e1412e316dae01  0.5.1_windows_386.zip
-    6c5c43aa92f41f23199b9142f08950e57e400e3fed9196132a111f65b499c214  0.5.1_windows_amd64.zip
+    32849dcbbb83b86d0d3f621705224ee580d3215f4060913f0bcbc974035ffd00  0.5.2_darwin_386.zip
+    1c3c881c4a29cc71617a87503557df684977d86b966f5ed0273298e2f6221594  0.5.2_darwin_amd64.zip
+    ca62ab9e2dc80c28c2f19e0aa50ec8ced3f64d51f7cd07169e3e12ec5cff34c8  0.5.2_freebsd_386.zip
+    ebb8a012e23d5c18ed64a038cd54ee7f57a3647e096ae4564f6917ec1fc27c4c  0.5.2_freebsd_amd64.zip
+    9bb5e20ae0ee42e390728b3ce0a599ec1ff0c77e83dcf755795e35a7723f2da1  0.5.2_freebsd_arm.zip
+    114b6ea3c623a048552d1464a34866f6d9738a3a5dcf62e606ced60c8958619f  0.5.2_linux_386.zip
+    813f856a3d326d2a65f561edac8050d981f93ea51da03b0fb6b3d72010a5fc96  0.5.2_linux_amd64.zip
+    44acbd9253687842c3ed71d9be9b0b73d894c112d338051ed4de1d00b158accc  0.5.2_linux_arm.zip
+    7732d8614e3df4f898947382041b35651c4fb69ac7e314737f647ef0fd8a6df4  0.5.2_openbsd_386.zip
+    7b4a10240da9c4f9ed37ce4b716240fac643c4d1bf02d07b46c15cad4785f053  0.5.2_openbsd_amd64.zip
+    8bc0dd5e8242c1c711a184d00ae7b506261df3e2ab3e63cc141d7a3fe95a2e5c  0.5.2_windows_386.zip
+    6bd9756f9a03c120134677b72ed15fe2bd29632932a709723f26b75e2338a291  0.5.2_windows_amd64.zip
 EOF
 node.default[:packer][:checksums] = Hash[
     node[:packer][:raw_checksums].split("\n").collect { |s| s.split.reverse }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'sit@hadapt.com'
 license          'Apache 2.0'
 description      'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.3.1'
 
 depends 'ark', '~> 0.4.0'


### PR DESCRIPTION
* Updates checksums.
* Bumps version number to 0.3.1.
* Adds missing tag to release 0.3.0.
* Adds tag to 0.3.1 release.