### PR TITLE
Add some serverspec tests

### DIFF
--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,43 @@
+require 'serverspec'
+
+include Serverspec::Helper::Exec
+include Serverspec::Helper::DetectOS
+
+describe 'packer' do
+
+  case os[:family]
+  when 'Centos', 'RedHat'
+    exec_location = '/usr/local/bin'
+    RSpec.configure do |c|
+      c.path = '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin'
+    end
+  when 'Ubuntu', 'Debian'
+    exec_location = '/usr/local/bin'
+  end
+
+  describe file("#{exec_location}/packer") do
+    it { should be_executable }
+  end
+
+  describe command('which packer') do
+    it { should return_stdout /#{exec_location}\/packer/}
+  end
+
+  describe command('packer -v') do
+    it { should return_stdout /Packer v0..*/ }
+  end
+
+  describe command('packer') do
+    it { should return_stdout "usage: packer [--version] [--help] <command> [<args>]
+
+Available commands are:
+    build       build image(s) from template
+    fix         fixes templates from old versions of packer
+    inspect     see components of a template
+    validate    check that a template is valid
+
+Globally recognized options:
+    -machine-readable    Machine-readable output format." }
+  end
+
+end


### PR DESCRIPTION
This should make it easier to confirm whether PR's work.  Just run `kitchen test` and it'll verify packer is installed correctly.  

4 simple tests:
- Looks for the packer executable
- Makes sure packer executable is returnable in the PATH
- Try a packer command and check version (currently a regex against any 0. release)
- Try a packer command without arguments and check default output.

Hope this helps, let me know if you have any issues with it.
