### PR TITLE
Upgraded to 0.7.2 Packer plus minor tweaks:

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,11 +52,11 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
+  #config.ssh.max_tries = 40
+  #config.ssh.timeout   = 120
 
   # The path to the Berksfile to use with Vagrant Berkshelf
-  # config.berkshelf.berksfile_path = "./Berksfile"
+  config.berkshelf.berksfile_path = "./Berksfile"
 
   # Enabling the Berkshelf plugin. To enable this globally, add this configuration
   # option to your ~/.vagrant.d/Vagrantfile file

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,25 +1,27 @@
 node.default[:packer][:url_base] = "https://dl.bintray.com/mitchellh/packer"
-node.default[:packer][:version] = "0.5.1"
+node.default[:packer][:version] = "0.7.2"
 node.default[:packer][:arch] = kernel['machine'] =~ /x86_64/ ? "amd64" : "386"
+node.default[:packer][:file_prefix] = Gem::Version.new('0.7.1') > Gem::Version.new(node.default[:packer][:version]) ? "" : "packer_"
+node.default[:packer][:file_url] = "#{node[:packer][:url_base]}/#{node[:packer][:file_prefix]}#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
 
+filename = "#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
 # Transform raw output of the bintray checksum list into a Hash[filename, checksum].
 # https://dl.bintray.com/mitchellh/packer/${VERSION}_SHA256SUMS?direct
 node.default[:packer][:raw_checksums] = <<-EOF
-    a0d8db4944d0024af05e256357cad014662eddefef67b1b2fe8a5060659a5be2  0.5.1_darwin_386.zip
-    56bec31f0d3540d566ef86979b25367660d7e72c010c9d87ef91c5c2138e9eae  0.5.1_darwin_amd64.zip
-    337651f4dd4f897413eb07e8d2cd821a0246d04c4235ce398af58f7939e097e1  0.5.1_freebsd_386.zip
-    ae356b68517aa75d08736c44d838b6bd4a19203315ee8afffff5de35684e1464  0.5.1_freebsd_amd64.zip
-    bbd2468d69195b4227034aa07474e87c2bcfe2250ae620085219e870e6b33bf6  0.5.1_freebsd_arm.zip
-    cc7741165a3d5f66c1d4af3ea3b1e80ebe03cb2ce5e0ff27ff43ecac64f1dc7a  0.5.1_linux_386.zip
-    fa68149f4356ad48a6393dbf9e81839a40aad115e5bad83833ff9ccf6a0239b8  0.5.1_linux_amd64.zip
-    6a6b724df3bc51478cc1cd4ccbc000924bbe9018a4ded74d3b6e0409cb9092e0  0.5.1_linux_arm.zip
-    a2ff5410a871baafef2ffd1924f5b6d7fe1ba443ba0b23071e2c928935d173e6  0.5.1_openbsd_386.zip
-    41c1edd5faf9041081f1dbaa6eb14e9f18cdb25a8dab85f33c08701bd0275817  0.5.1_openbsd_amd64.zip
-    350480400d31c00e1604fce8744b5f3d279c15cf8c49cd7b59e1412e316dae01  0.5.1_windows_386.zip
-    6c5c43aa92f41f23199b9142f08950e57e400e3fed9196132a111f65b499c214  0.5.1_windows_amd64.zip
+    00c73eba76139869e39377e6c342e937d36f1a1b81920f4948608c5c10455190  packer_0.7.2_darwin_386.zip
+    bed7ddc255b5b71b139de5e30d4221926cd314a87baf0b937ba7a97c196b1286  packer_0.7.2_darwin_amd64.zip
+    8f0db25bebdfb83d6f0525523fd775489e95a11d3efdaff73db1d3e3e62fc54d  packer_0.7.2_freebsd_386.zip
+    e5110e8eeeb8af659f22e66fb23a2bd6227ddb68503727cacedd21a53369c5b1  packer_0.7.2_freebsd_amd64.zip
+    4c2bf9681092a4460735eee6611f0474ce7525ccfb8cd4403b58feedf74c629a  packer_0.7.2_freebsd_arm.zip
+    a0a03b9eb9f1199a294b6a8732fd76e625f22d263e20ebc2c377d2d95cfb2242  packer_0.7.2_linux_386.zip
+    2e0a7971d0df81996ae1db0fe04291fb39a706cc9e8a2a98e9fe735c7289379f  packer_0.7.2_linux_amd64.zip
+    88092001573c2b198705e76c91f557150e029ac2f9076f30bd9f4f6e2a0a66dc  packer_0.7.2_linux_arm.zip
+    a8b934ad0466a47f42deb6d5323e07e254dc038c2a6eeb562a333990358f961c  packer_0.7.2_openbsd_386.zip
+    30e81878fe8581c30658826787780dece85f5de459527d5ec9884e97e3caa8ab  packer_0.7.2_openbsd_amd64.zip
+    13dd82b4528c20f409ad87f7ffb39cd5197c050165ad41cbf3ea33fc1418eab6  packer_0.7.2_windows_386.zip
+    33d6853d674f38d9bdc982c99e58ded6df2e908203a6a06aa948c38d9c779fc4  packer_0.7.2_windows_amd64.zip
 EOF
 node.default[:packer][:checksums] = Hash[
     node[:packer][:raw_checksums].split("\n").collect { |s| s.split.reverse }
 ]
-filename = "#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
 node.default[:packer][:checksum] = node[:packer][:checksums][filename]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,13 +3,13 @@
 # Recipe:: default
 #
 # Copyright (C) 2013 Hadapt, Inc.
-# 
+#
 
 # Install packages necessary for extracting stuff
 include_recipe "ark"
 
 ark 'packer' do
-    url "#{node[:packer][:url_base]}/#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
+    url "#{node[:packer][:file_url]}"
     version node[:packer][:version]
     checksum node[:packer][:checksum]
     has_binaries ["packer"]

--- a/test/integration/default/bats/packer_installed.bats
+++ b/test/integration/default/bats/packer_installed.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "packer binary is found in PATH" {
+  run which packer
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Vagrantfile
-Vagrant was complaining about not finding Berksfile (ChefDK 0.3.5) so I had to specify the path
-Vagrant complained that max_tries and timeout needed to be commented out...so I commented them out!

attributes/default.rb
-Updated to 0.7.2 Hashes and updated version
-Added logic to download file naming scheme, newer versions are prefixed with "packer_"
-Moved complete "file_url" as an attribute instead of specified in the recipe.

recipes/default.rb
-Now using new "file_url" from attributes

test/integration/default/bats/packer_installed.bats
-Added bats test to confirm packer was installed
