### PR TITLE
Fix file name issue with Packer 0.7.0 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ This will put Packer into `/usr/local` in a `packer-*version*` directory, with a
 * `node[:packer][:raw_checksums]` - The contents of the upstream checksum file to allow checksum auto-detection.
 * `node[:packer][:checksums]` - A `Hash` mapping file name to checksums, derived by default from `raw_checksums`.
 * `node[:packer][:checksum]` - SHA-256 checksum of appropriate binary. Should be auto-detected for the default version using data in `raw_checksums` or `checksums`.
+* `node[:packer][:filename_format]` - A `String` used as a template for Packer's URL filename. Note that it's `'packer_%{version}_%{os}_%{arch}'` as of 0.7.0 and above (the current default). If you need to stick with any older version (0.6.1 and below), please change this attribute to `'%{version}_%{os}_%{arch}.zip'` instead.
+# `node[:packer][:filename]` - The file name to be used. Change this directly to bypass the use of `node[:packer][:filename_format]`.
 
 When overriding with a particular desired version, you can set the checksum a variety of ways. When
 this cookbook is updated for a new default version, the checksums will be updated by the maintainers.
 
 If you require a particular older (or newer) version, you can update the
 `raw_checksums` with the official SHA256SUM list from
-`https://dl.bintray.com/mitchellh/packer/${VERSION}_SHA256SUMS?direct`
+`https://dl.bintray.com/mitchellh/packer/packer_${VERSION}_SHA256SUMS?direct`
 (easiest), directly override the `checksums` attribute with an explicit map of
 just the versions you want (somewhat more work for you), or just directly
 setting the `checksum` attribute (if you only need a single platform).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,25 +1,38 @@
-node.default[:packer][:url_base] = "https://dl.bintray.com/mitchellh/packer"
-node.default[:packer][:version] = "0.5.1"
-node.default[:packer][:arch] = kernel['machine'] =~ /x86_64/ ? "amd64" : "386"
+node.default[:packer][:url_base] = 'https://dl.bintray.com/mitchellh/packer'
+node.default[:packer][:version] = '0.7.5'
+node.default[:packer][:arch] = kernel['machine'] =~ /x86_64/ ? 'amd64' : '386'
 
 # Transform raw output of the bintray checksum list into a Hash[filename, checksum].
 # https://dl.bintray.com/mitchellh/packer/${VERSION}_SHA256SUMS?direct
 node.default[:packer][:raw_checksums] = <<-EOF
-    a0d8db4944d0024af05e256357cad014662eddefef67b1b2fe8a5060659a5be2  0.5.1_darwin_386.zip
-    56bec31f0d3540d566ef86979b25367660d7e72c010c9d87ef91c5c2138e9eae  0.5.1_darwin_amd64.zip
-    337651f4dd4f897413eb07e8d2cd821a0246d04c4235ce398af58f7939e097e1  0.5.1_freebsd_386.zip
-    ae356b68517aa75d08736c44d838b6bd4a19203315ee8afffff5de35684e1464  0.5.1_freebsd_amd64.zip
-    bbd2468d69195b4227034aa07474e87c2bcfe2250ae620085219e870e6b33bf6  0.5.1_freebsd_arm.zip
-    cc7741165a3d5f66c1d4af3ea3b1e80ebe03cb2ce5e0ff27ff43ecac64f1dc7a  0.5.1_linux_386.zip
-    fa68149f4356ad48a6393dbf9e81839a40aad115e5bad83833ff9ccf6a0239b8  0.5.1_linux_amd64.zip
-    6a6b724df3bc51478cc1cd4ccbc000924bbe9018a4ded74d3b6e0409cb9092e0  0.5.1_linux_arm.zip
-    a2ff5410a871baafef2ffd1924f5b6d7fe1ba443ba0b23071e2c928935d173e6  0.5.1_openbsd_386.zip
-    41c1edd5faf9041081f1dbaa6eb14e9f18cdb25a8dab85f33c08701bd0275817  0.5.1_openbsd_amd64.zip
-    350480400d31c00e1604fce8744b5f3d279c15cf8c49cd7b59e1412e316dae01  0.5.1_windows_386.zip
-    6c5c43aa92f41f23199b9142f08950e57e400e3fed9196132a111f65b499c214  0.5.1_windows_amd64.zip
+    72d57fe6a6ec2660dda2aed73198a4c4d9152037831d6aa44c64a28307c299c7  packer_0.7.5_darwin_386.zip
+    c0e149c4515fe548c1daeafabec3b4a091f2aa0c6936723382b3f6fe5a617880  packer_0.7.5_darwin_amd64.zip
+    6bce28c51a1862cbc3071421546620fb27007732f7a8470054e7267ca3521b95  packer_0.7.5_freebsd_386.zip
+    508293b60f525c44560ca569db5b63b6f92294f655c61b076243a98a0ea75604  packer_0.7.5_freebsd_amd64.zip
+    1cef5f1875a19b9c46daca5f36739bf2e9c9d68b1f27319abdc36c02837ac662  packer_0.7.5_freebsd_arm.zip
+    6a6ee79d51909f04f734c15a0e12ebcaba3f2cf4d449906f6a186490774262f9  packer_0.7.5_linux_386.zip
+    8fab291c8cc988bd0004195677924ab6846aee5800b6c8696d71d33456701ef6  packer_0.7.5_linux_amd64.zip
+    8a7d63f0a9282f7b0a833a8455d37f5916d5a9200c17c83627922e08ed9ec2ca  packer_0.7.5_linux_arm.zip
+    986d3b038f54ef86de313b10d45248c78159ebf5850615ab326d6e57229086a6  packer_0.7.5_openbsd_386.zip
+    c11a67715de000de6742ebe7fb7187ba1db08333ec3941111a72672f0eb27509  packer_0.7.5_openbsd_amd64.zip
+    99b879f491df08fa217193edea0b777341c73d4a145f2329b5c795d821258536  packer_0.7.5_windows_386.zip
+    1dccdb825bbdd3487747771f58cecb5cbd0a73d44b52958f0d09ac9086b861b9  packer_0.7.5_windows_amd64.zip
 EOF
 node.default[:packer][:checksums] = Hash[
     node[:packer][:raw_checksums].split("\n").collect { |s| s.split.reverse }
 ]
-filename = "#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
+
+#
+# Since 0.7.0, the URL format has been changed to:
+# - https://dl.bintray.com/mitchellh/packer/packer_${VERSION}_${OS}_${ARCH}.zip
+# Older versions (0.6.1 and below) use:
+# - https://dl.bintray.com/mitchellh/packer/packer_${VERSION}_${OS}_${ARCH}.zip
+#
+# Make sure you change `node[:packer][:filename_format]` to
+# '%{version}_%{os}_%{arch}.zip' when you need to stick with the old.
+#
+node.default[:packer][:filename_format] = 'packer_%{version}_%{os}_%{arch}.zip'
+filename = node[:packer][:filename_format] % { :version => node[:packer][:version], :os => node[:os], :arch => node[:packer][:arch] }
+
+node.default[:packer][:filename] = filename
 node.default[:packer][:checksum] = node[:packer][:checksums][filename]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'sit@hadapt.com'
 license          'Apache 2.0'
 description      'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.0'
+version          '0.3.1'
 
 depends 'ark', '~> 0.4.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,13 +6,13 @@
 # 
 
 # Install packages necessary for extracting stuff
-include_recipe "ark"
+include_recipe 'ark'
 
 ark 'packer' do
-    url "#{node[:packer][:url_base]}/#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
+    url "#{node[:packer][:url_base]}/#{node[:packer][:filename]}"
     version node[:packer][:version]
     checksum node[:packer][:checksum]
-    has_binaries ["packer"]
+    has_binaries ['packer']
     append_env_path false
     strip_leading_dir false
 


### PR DESCRIPTION
Pull request for issue #14. `node[:packer][:filename_format]` is added for more flexibility in specifying the filename for different packer versions (`packer_${VERSION}_${OS}_${ARCH}.zip` as of 0.7.0).