### PR TITLE
use version 0.9.x of ark cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,4 @@ description      'Installs/Configures packer'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.0'
 
-depends 'ark', '~> 0.4.0'
+depends 'ark', '~> 0.9.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,7 @@ ark 'packer' do
     checksum node[:packer][:checksum]
     has_binaries ["packer"]
     append_env_path false
-    strip_leading_dir false
+    strip_components 0
 
     action :install
 end


### PR DESCRIPTION
Version 0.9.x of the ark cookbook improves platform support.