### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,7 +9,7 @@
 include_recipe "ark"
 
 ark 'packer' do
-    url "#{node[:packer][:url_base]}_#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
+    url "#{node[:packer][:url_base]}/packer_#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
     version node[:packer][:version]
     checksum node[:packer][:checksum]
     has_binaries ["packer"]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,7 +9,7 @@
 include_recipe "ark"
 
 ark 'packer' do
-    url "#{node[:packer][:url_base]}/#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
+    url "#{node[:packer][:url_base]}_#{node[:packer][:version]}_#{node[:os]}_#{node[:packer][:arch]}.zip"
     version node[:packer][:version]
     checksum node[:packer][:checksum]
     has_binaries ["packer"]


### PR DESCRIPTION
The previous url resulted in a download error because of having the wrong link:  WARN: remote_file[/var/chef/cache/packer.zip] cannot be downloaded from https://dl.bintray.com/mitchellh/packer/0.7.5_linux_amd64.zip: 404 "Not Found" whereas the real link is: https://dl.bintray.com/mitchellh/packer/packer_0.7.5_linux_amd64.zip