### PR TITLE
Fix attribute issue with new chef version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 node.default['packer']['url_base'] = 'https://releases.hashicorp.com/packer'
 node.default['packer']['version'] = '0.12.0'
 node.default['packer'][node.default['packer']['version']]['prefix'] = ''
-node.default['packer']['arch'] = kernel['machine'] =~ /x86_64/ ? "amd64" : "386"
+node.default['packer']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "386"
 
 # Transform raw output of the bintray checksum list into a Hash[filename, checksum].
 # https://dl.bintray.com/mitchellh/packer/${VERSION}_SHA256SUMS?direct


### PR DESCRIPTION
Check out https://github.com/daptiv/seven_zip/issues/21 for another codebase experiencing a similar issue, probably based on new versions of Chef. 

I ran into this error while provisioning in chef-solo with chef-client version `13.0.118`